### PR TITLE
chore: pin unpkg link to current major version

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,7 +3,7 @@
 <head>
     <title>Microsoft Teams Service for IFTTT</title>
     
-    <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+    <script src="https://unpkg.com/@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
 
     <style>
         @font-face {


### PR DESCRIPTION
Adding major version to unpkg link to prevent future major version releases of mgt breaking this repo